### PR TITLE
Fix get_elements with dict response

### DIFF
--- a/dendrite_sdk/_core/dendrite_page.py
+++ b/dendrite_sdk/_core/dendrite_page.py
@@ -734,7 +734,7 @@ class DendritePage(Generic[DownloadType]):
 
         results = await asyncio.gather(*tasks)
         elements_dict: Dict[str, DendriteElement] = {}
-        for element, field_name in zip(results, elements_dict.keys()):
+        for element, field_name in zip(results, prompt_dict.keys()):
             elements_dict[field_name] = element
         return DendriteElementsResponse(elements_dict)
 


### PR DESCRIPTION
Due to a small issue the dict response overload for `get_elements`, no results are returned.

`prompt_dict` should be used instead of the newly instantiated `elements_dict`, which is empty.

This PR fixes the issue.