### PR TITLE
Remove optional from timeout

### DIFF
--- a/dendrite_sdk/_core/_base_browser.py
+++ b/dendrite_sdk/_core/_base_browser.py
@@ -138,7 +138,7 @@ class BaseDendriteBrowser(ABC, Generic[DownloadType]):
         self,
         url: str,
         new_page: bool = False,
-        timeout: Optional[float] = 15000,
+        timeout: float = 15000,
         expected_page: str = "",
     ) -> DendritePage[DownloadType]:
         """
@@ -146,9 +146,9 @@ class BaseDendriteBrowser(ABC, Generic[DownloadType]):
 
         Args:
             url (str): The URL to navigate to.
-            new_page (bool, optional): Whether to open the URL in a new page. Defaults to False.
-            timeout (Optional[float], optional): The maximum time (in milliseconds) to wait for the page to load. Defaults to 15000.
-            expected_page (str, optional): A description of the expected page type for verification. Defaults to an empty string.
+            new_page (bool): Whether to open the URL in a new page. Defaults to False.
+            timeout (float): The maximum time (in milliseconds) to wait for the page to load. Defaults to 15000.
+            expected_page (str): A description of the expected page type for verification. Defaults to an empty string.
 
         Returns:
             DendritePage: The page object after navigation.

--- a/dendrite_sdk/_core/dendrite_page.py
+++ b/dendrite_sdk/_core/dendrite_page.py
@@ -97,7 +97,7 @@ class DendritePage(Generic[DownloadType]):
     async def goto(
         self,
         url: str,
-        timeout: Optional[float] = 30000,
+        timeout: float = 30000,
         wait_until: Optional[
             Literal["commit", "domcontentloaded", "load", "networkidle"]
         ] = "load",
@@ -107,7 +107,7 @@ class DendritePage(Generic[DownloadType]):
 
         Args:
             url (str): The URL to navigate to.
-            timeout (Optional[float]): Maximum navigation time in milliseconds.
+            timeout (float): Maximum navigation time in milliseconds.
             wait_until (Optional[Literal["commit", "domcontentloaded", "load", "networkidle"]]):
                 When to consider navigation succeeded.
         """


### PR DESCRIPTION
I noticed that in the `goto` the type for `timeout` was `Optional[float]` while everywhere else `timeout` is just `float`. The `Optional[float]` means `None` is a valid value for `timeout` in `goto` and it never times out. Because the other timeouts don't allow this it makes me think it wasn't intended in `goto` either. Feel free to close this if I'm wrong and it was done on purpose.

 In `BaseDendriteBrowser` `goto` I updated the other args when updating `timeout` because these values aren't really optional (i.e. accept `None`), instead they get set to default values if the user doesn't pass them. If you prefer the original I can change it back.