### PR TITLE
Add py.typed file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+include = ["dendrite_sdk/py.typed"]
 
 
 


### PR DESCRIPTION
This adds a `py.typed` file so type checkers can work instead of erroring

Before:

```sh
~/development/python/t ❯  main [?] ❯ 🐍 v3.12.5 (.venv) 🐧 ❯ mypy .
t/main.py:3: error: Cannot find implementation or library stub for module named "dendrite_sdk"  [import-not-found]
t/main.py:3: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 6 source files)
```

After:

```sh
~/development/python/t ❯  main [?] ❯ 🐍 v3.12.5 (.venv) 🐧 ❯ mypy .
Success: no issues found in 6 source files
```