### PR TITLE
Den 269 Update download to work with sync

### DIFF
--- a/dendrite_sdk/_common/event_sync.py
+++ b/dendrite_sdk/_common/event_sync.py
@@ -1,79 +1,31 @@
 import asyncio
-from typing import Generic, Optional, TypeVar
-
-from dendrite_sdk._exceptions.dendrite_exception import DendriteException
-
-
-T = TypeVar("T")
+from typing import Generic, Optional, Type, TypeVar, Union, cast
+import playwright
+from playwright.async_api import Page, Download, FileChooser
+import playwright.sync_api
 
 
-class EventSync(Generic[T]):
-    """
-    EventSync is a synchronization utility class that allows for setting and retrieving data
-    across asynchronous tasks using an asyncio event. The class is generic and can be used with
-    any data type.
+Events = TypeVar("Events", Download, FileChooser)
 
-    This class is useful for scenarios where one task needs to wait for data to be provided
-    by another task, with support for timeouts.
+mapping = {
+    Download: "download",
+    FileChooser: "filechooser",
+}
 
-    Attributes:
-        event (asyncio.Event): The asyncio event that signals when data is ready to be retrieved.
-        data (Optional[T]): The data associated with the event, of a generic type `T`.
 
-    Methods:
-        set_event(data: T) -> None:
-            Sets the event and stores the provided data.
+class EventSync(Generic[Events]):
+    def __init__(self, event_type: Type[Events]):
+        self.event_type = event_type
 
-        get_data(timeout: float = 30000) -> T:
-            Waits for the event to be set and retrieves the associated data, with an optional timeout.
-    """
-
-    def __init__(self) -> None:
-        self.event = asyncio.Event()
-        self.data: Optional[T] = None
-
-    def set_event(self, data: T) -> None:
-        """
-        Sets the event and stores the provided data.
-
-        This method is used to signal that the data is ready to be retrieved by any waiting tasks.
-
-        Args:
-            data (T): The data to be stored and associated with the event.
-
-        Returns:
-            None
-        """
-        self.data = data
-        self.event.set()
-
-    async def get_data(self, timeout: float = 30000) -> T:
-        """
-        Waits for the event to be set and retrieves the associated data.
-
-        This method waits for the event to be set by another task and then returns the stored data.
-        If the event is not set within the specified timeout, a TimeoutError is raised.
-
-        Args:
-            timeout (float, optional): The maximum time (in milliseconds) to wait for the event to be set. Defaults to 30000.
-
-        Returns:
-            T: The data associated with the event.
-
-        Raises:
-            TimeoutError: If the event is not set within the specified timeout.
-            Exception: If the event is set but no data is available.
-        """
+    async def get_data(self, pw_page: Page, timeout: float = 30000) -> Events:
         try:
-            await asyncio.wait_for(self.event.wait(), timeout * 0.001)
-            if not self.data:
-                raise DendriteException(f"No {self.data.__class__.__name__} was found.")
-            data = self.data
+            data = await pw_page.wait_for_event(
+                mapping[self.event_type], timeout=timeout
+            )
+            this_type = self.event_type
+            return cast(this_type, data)
 
-            self.data = None
-            self.event.clear()
-            return data
-        except asyncio.TimeoutError:
+        except playwright.sync_api.TimeoutError:
             raise TimeoutError(
-                f"There was no {self.data.__class__.__name__} event set within the specified timeout."
+                f"There was no '{self.event_type}' event set within the specified timeout."
             )

--- a/dendrite_sdk/_core/_base_browser.py
+++ b/dendrite_sdk/_core/_base_browser.py
@@ -10,6 +10,7 @@ from playwright.async_api import (
     BrowserContext,
     FileChooser,
     Download,
+    Page,
 )
 
 from dendrite_sdk._api.dto.authenticate_dto import AuthenticateDTO
@@ -112,8 +113,8 @@ class BaseDendriteBrowser(ABC):
         self._browser_api_client = BrowserAPIClient(dendrite_api_key, self._id)
         self.playwright: Optional[Playwright] = None
         self.browser_context: Optional[BrowserContext] = None
-        self._upload_handler = EventSync[FileChooser]()
-        self._download_handler = EventSync[Download]()
+        self._upload_handler = EventSync(event_type=FileChooser)
+        self._download_handler = EventSync(event_type=Download)
         self.closed = False
 
         llm_config = LLMConfig(
@@ -358,7 +359,7 @@ class BaseDendriteBrowser(ABC):
         return self._active_page_manager
 
     @abstractmethod
-    async def _get_download(self, timeout: float) -> Download:
+    async def _get_download(self, pw_page: Page, timeout: float) -> Download:
         """
         Retrieves the download event from the browser.
 
@@ -370,7 +371,9 @@ class BaseDendriteBrowser(ABC):
         """
         pass
 
-    async def _get_filechooser(self, timeout: float = 30000) -> FileChooser:
+    async def _get_filechooser(
+        self, pw_page: Page, timeout: float = 30000
+    ) -> FileChooser:
         """
         Uploads files to the browser.
 
@@ -383,4 +386,4 @@ class BaseDendriteBrowser(ABC):
         Raises:
             Exception: If there is an issue uploading files.
         """
-        return await self._upload_handler.get_data(timeout=timeout)
+        return await self._upload_handler.get_data(pw_page, timeout=timeout)

--- a/dendrite_sdk/_core/_managers/page_manager.py
+++ b/dendrite_sdk/_core/_managers/page_manager.py
@@ -50,14 +50,6 @@ class PageManager:
             else:
                 pass
 
-    async def _file_chooser_handler(self, file_chooser: FileChooser):
-        if self.active_page:
-            self.dendrite_browser._upload_handler.set_event(file_chooser)
-
-    async def _download_handler(self, download: Download):
-        if self.active_page:
-            self.dendrite_browser._download_handler.set_event(download)
-
     async def _page_on_crash_handler(self, page: Page):
         logger.error(f"Page crashed: {page.url}")
         await page.reload()
@@ -65,8 +57,6 @@ class PageManager:
     def _page_on_open_handler(self, page: Page):
         page.on("close", self._page_on_close_handler)
         page.on("crash", self._page_on_crash_handler)
-        page.on("filechooser", self._file_chooser_handler)
-        page.on("download", self._download_handler)
 
         dendrite_page = DendritePage(page, self.dendrite_browser)
         self.pages.append(dendrite_page)

--- a/dendrite_sdk/_core/dendrite_browser.py
+++ b/dendrite_sdk/_core/dendrite_browser.py
@@ -1,4 +1,4 @@
-from playwright.async_api import FileChooser, Download
+from playwright.async_api import FileChooser, Download, Page
 from dendrite_sdk._core._base_browser import BaseDendriteBrowser
 
 
@@ -26,7 +26,7 @@ class DendriteBrowser(BaseDendriteBrowser):
         Exception: If any of the required API keys (Dendrite, OpenAI, Anthropic) are not provided or found in the environment variables.
     """
 
-    async def _get_download(self, timeout: float = 30000) -> Download:
+    async def _get_download(self, pw_page: Page, timeout: float = 30000) -> Download:
         """
         Retrieves the download event from the browser.
 
@@ -38,9 +38,11 @@ class DendriteBrowser(BaseDendriteBrowser):
         Raises:
             Exception: If there is an issue retrieving the download event.
         """
-        return await self._download_handler.get_data(timeout)
+        return await self._download_handler.get_data(pw_page, timeout)
 
-    async def _get_filechooser(self, timeout: float = 30000) -> FileChooser:
+    async def _get_filechooser(
+        self, pw_page: Page, timeout: float = 30000
+    ) -> FileChooser:
         """
         Uploads files to the browser.
 
@@ -52,4 +54,4 @@ class DendriteBrowser(BaseDendriteBrowser):
         Raises:
             Exception: If there is an issue uploading files.
         """
-        return await self._upload_handler.get_data(timeout)
+        return await self._upload_handler.get_data(pw_page, timeout)

--- a/dendrite_sdk/_core/dendrite_page.py
+++ b/dendrite_sdk/_core/dendrite_page.py
@@ -112,7 +112,7 @@ class DendritePage(ExtractionMixin, AskMixin, GetElementMixin):
         Returns:
             The downloaded file data.
         """
-        return await self.dendrite_browser._get_download(timeout)
+        return await self.dendrite_browser._get_download(self.playwright_page, timeout)
 
     def _get_context(self, element: Any) -> Union[Page, FrameLocator]:
         """
@@ -357,7 +357,6 @@ class DendritePage(ExtractionMixin, AskMixin, GetElementMixin):
         element = await self.get_element(
             prompt,
             use_cache=use_cache,
-            max_retries=max_retries,
             timeout=timeout,
         )
 
@@ -381,7 +380,6 @@ class DendritePage(ExtractionMixin, AskMixin, GetElementMixin):
         value: str,
         expected_outcome: Optional[str] = None,
         use_cache: bool = True,
-        max_retries: int = 3,
         timeout: int = 2000,
         *args,
         kwargs={},
@@ -411,7 +409,6 @@ class DendritePage(ExtractionMixin, AskMixin, GetElementMixin):
         element = await self.get_element(
             prompt,
             use_cache=use_cache,
-            max_retries=max_retries,
             timeout=timeout,
         )
 
@@ -451,7 +448,9 @@ class DendritePage(ExtractionMixin, AskMixin, GetElementMixin):
         Returns:
             None
         """
-        file_chooser = await self.dendrite_browser._get_filechooser(timeout)
+        file_chooser = await self.dendrite_browser._get_filechooser(
+            self.playwright_page, timeout
+        )
         await file_chooser.set_files(files)
 
     async def get_content(self):

--- a/dendrite_sdk/_core/dendrite_remote_browser.py
+++ b/dendrite_sdk/_core/dendrite_remote_browser.py
@@ -1,7 +1,7 @@
 import os
 from typing import Any, Generic, Optional, TypeVar
 
-from playwright.async_api import async_playwright, Download
+from playwright.async_api import async_playwright, Download, Page
 
 from dendrite_sdk._common.constants import STEALTH_ARGS
 from dendrite_sdk._core._managers.page_manager import PageManager
@@ -55,5 +55,5 @@ class DendriteRemoteBrowser(BaseDendriteBrowser, Generic[T]):
         await self._provider._close(self)
         await super().close()
 
-    async def _get_download(self, timeout: float) -> Download:
-        return await self._provider.get_download(self, timeout)
+    async def _get_download(self, pw_page: Page, timeout: float) -> Download:
+        return await self._provider.get_download(self, pw_page, timeout)

--- a/dendrite_sdk/_core/mixin/get_element.py
+++ b/dendrite_sdk/_core/mixin/get_element.py
@@ -236,7 +236,7 @@ class GetElementMixin(DendritePageProtocol):
             )
 
             elapsed_time = time.time() - start_time
-            remaining_time = timeout*0.001 - elapsed_time
+            remaining_time = timeout * 0.001 - elapsed_time
 
             if remaining_time <= 10 or attempt > 2:
                 force_not_use_cache = True

--- a/dendrite_sdk/_core/protocol/page_protocol.py
+++ b/dendrite_sdk/_core/protocol/page_protocol.py
@@ -1,5 +1,4 @@
-from asyncio import Protocol
-from typing import Any, List, TYPE_CHECKING
+from typing import Any, List, TYPE_CHECKING, Protocol
 
 from dendrite_sdk._api.browser_api_client import BrowserAPIClient
 from dendrite_sdk._core.models.page_information import PageInformation

--- a/dendrite_sdk/ext/_remote_provider.py
+++ b/dendrite_sdk/ext/_remote_provider.py
@@ -1,5 +1,5 @@
 from typing import TYPE_CHECKING
-from playwright.async_api import Browser, Playwright, Download
+from playwright.async_api import Browser, Playwright, Download, Page
 
 from abc import ABC, abstractmethod
 
@@ -22,6 +22,6 @@ class RemoteProvider(ABC):
 
     @abstractmethod
     async def get_download(
-        self, DendriteRemoteBrowser, timeout: float = 30000
+        self, DendriteRemoteBrowser, pw_page: Page, timeout: float = 30000
     ) -> Download:
         pass

--- a/dendrite_sdk/ext/browserbase/_provider.py
+++ b/dendrite_sdk/ext/browserbase/_provider.py
@@ -1,7 +1,7 @@
 import os
 from typing import Optional
 from loguru import logger
-from playwright.async_api import Playwright, Locator
+from playwright.async_api import Playwright, Page
 from dendrite_sdk._core.dendrite_remote_browser import DendriteRemoteBrowser
 from dendrite_sdk.ext._remote_provider import RemoteProvider
 from dendrite_sdk.ext.browserbase._download import BrowserbaseDownload
@@ -66,13 +66,13 @@ class BrowserbaseProvider(RemoteProvider):
         )
 
     async def get_download(
-        self, dendrite_browser: DendriteRemoteBrowser, timeout
+        self, dendrite_browser: DendriteRemoteBrowser, pw_page: Page, timeout: float
     ) -> BrowserbaseDownload:
         if not self._session_id:
             raise ValueError(
                 "Downloads are not enabled for this provider. Specify enable_downloads=True in the constructor"
             )
-        download = await dendrite_browser._download_handler.get_data(timeout)
+        download = await dendrite_browser._download_handler.get_data(pw_page, timeout)
         await self._client.save_downloads_on_disk(
             self._session_id, await download.path(), 30
         )


### PR DESCRIPTION
closes den-269
Rewrite EventSync so it's not dependent on external events. Uses Playwrights event system instead