### PR TITLE
Upload and download available on BaseDendrite. 

### DIFF
--- a/dendrite_sdk/async_api/_core/_base_browser.py
+++ b/dendrite_sdk/async_api/_core/_base_browser.py
@@ -28,6 +28,7 @@ from dendrite_sdk.async_api._core.mixin.extract import ExtractionMixin
 from dendrite_sdk.async_api._core.mixin.fill_fields import FillFieldsMixin
 from dendrite_sdk.async_api._core.mixin.get_element import GetElementMixin
 from dendrite_sdk.async_api._core.mixin.keyboard import KeyboardMixin
+from dendrite_sdk.async_api._core.mixin.upload_download_mixin import DownloadUploadMixin
 from dendrite_sdk.async_api._core.mixin.wait_for import WaitForMixin
 from dendrite_sdk.async_api._core.models.authentication import (
     AuthSession,
@@ -43,6 +44,7 @@ from dendrite_sdk._common._exceptions.dendrite_exception import (
 
 
 class BaseAsyncDendrite(
+    DownloadUploadMixin,
     ExtractionMixin,
     WaitForMixin,
     AskMixin,

--- a/dendrite_sdk/async_api/_core/dendrite_page.py
+++ b/dendrite_sdk/async_api/_core/dendrite_page.py
@@ -20,7 +20,6 @@ from playwright.async_api import (
     FrameLocator,
     Keyboard,
     Download,
-    FilePayload,
 )
 
 
@@ -131,18 +130,6 @@ class AsyncPage(
             url = f"https://{url}"
 
         await self.playwright_page.goto(url, timeout=timeout, wait_until=wait_until)
-
-    async def get_download(self, timeout: float = 30000) -> Download:
-        """
-        Retrieves the download event associated with.
-
-        Args:
-            timeout (float, optional): The maximum amount of time (in milliseconds) to wait for the download to complete. Defaults to 30.
-
-        Returns:
-            The downloaded file data.
-        """
-        return await self.dendrite_browser._get_download(self.playwright_page, timeout)
 
     def _get_context(self, element: Any) -> Union[PlaywrightPage, FrameLocator]:
         """
@@ -291,33 +278,6 @@ class AsyncPage(
             None
         """
         await self.scroll_to_bottom()
-
-    async def upload_files(
-        self,
-        files: Union[
-            str,
-            pathlib.Path,
-            FilePayload,
-            Sequence[Union[str, pathlib.Path]],
-            Sequence[FilePayload],
-        ],
-        timeout: float = 30000,
-    ) -> None:
-        """
-        Uploads files to the page using a file chooser.
-
-        Args:
-            files (Union[str, pathlib.Path, FilePayload, Sequence[Union[str, pathlib.Path]], Sequence[FilePayload]]): The file(s) to be uploaded.
-                This can be a file path, a `FilePayload` object, or a sequence of file paths or `FilePayload` objects.
-            timeout (float, optional): The maximum amount of time (in milliseconds) to wait for the file chooser to be ready. Defaults to 30.
-
-        Returns:
-            None
-        """
-        file_chooser = await self.dendrite_browser._get_filechooser(
-            self.playwright_page, timeout
-        )
-        await file_chooser.set_files(files)
 
     async def get_content(self):
         """

--- a/dendrite_sdk/async_api/_core/mixin/upload_download_mixin.py
+++ b/dendrite_sdk/async_api/_core/mixin/upload_download_mixin.py
@@ -1,0 +1,53 @@
+import pathlib
+from typing import Sequence, Union
+
+from playwright.async_api import (
+    Download,
+    FilePayload,
+)
+from dendrite_sdk.async_api._core.protocol.page_protocol import DendritePageProtocol
+
+
+class DownloadUploadMixin(DendritePageProtocol):
+
+    async def get_download(self, timeout: float = 30000) -> Download:
+        """
+        Gets the most recent download from the browser.
+
+        Args:
+            timeout (float, optional): The maximum amount of time (in milliseconds) to wait for the download to complete. Defaults to 30.
+
+        Returns:
+            The downloaded file data.
+        """
+        browser = self._get_dendrite_browser()
+        page = await self._get_page()
+        download = await browser._get_download(page.playwright_page, timeout)
+        return download
+
+    async def upload_files(
+        self,
+        files: Union[
+            str,
+            pathlib.Path,
+            FilePayload,
+            Sequence[Union[str, pathlib.Path]],
+            Sequence[FilePayload],
+        ],
+        timeout: float = 30000,
+    ) -> None:
+        """
+        Uploads files to the page using a file chooser.
+
+        Args:
+            files (Union[str, pathlib.Path, FilePayload, Sequence[Union[str, pathlib.Path]], Sequence[FilePayload]]): The file(s) to be uploaded.
+                This can be a file path, a `FilePayload` object, or a sequence of file paths or `FilePayload` objects.
+            timeout (float, optional): The maximum amount of time (in milliseconds) to wait for the file chooser to be ready. Defaults to 30.
+
+        Returns:
+            None
+        """
+        browser = self._get_dendrite_browser()
+        page = await self._get_page()
+        file_chooser = await browser._get_filechooser(page.playwright_page, timeout)
+        await file_chooser.set_files(files)

--- a/dendrite_sdk/sync_api/_core/_base_browser.py
+++ b/dendrite_sdk/sync_api/_core/_base_browser.py
@@ -24,6 +24,7 @@ from dendrite_sdk.sync_api._core.mixin.extract import ExtractionMixin
 from dendrite_sdk.sync_api._core.mixin.fill_fields import FillFieldsMixin
 from dendrite_sdk.sync_api._core.mixin.get_element import GetElementMixin
 from dendrite_sdk.sync_api._core.mixin.keyboard import KeyboardMixin
+from dendrite_sdk.sync_api._core.mixin.upload_download_mixin import DownloadUploadMixin
 from dendrite_sdk.sync_api._core.mixin.wait_for import WaitForMixin
 from dendrite_sdk.sync_api._core.models.authentication import AuthSession
 from dendrite_sdk.sync_api._core.models.api_config import APIConfig
@@ -36,6 +37,7 @@ from dendrite_sdk._common._exceptions.dendrite_exception import (
 
 
 class BaseDendrite(
+    DownloadUploadMixin,
     ExtractionMixin,
     WaitForMixin,
     AskMixin,

--- a/dendrite_sdk/sync_api/_core/dendrite_page.py
+++ b/dendrite_sdk/sync_api/_core/dendrite_page.py
@@ -5,7 +5,7 @@ import time
 from typing import TYPE_CHECKING, Any, List, Literal, Optional, Sequence, Union
 from bs4 import BeautifulSoup, Tag
 from loguru import logger
-from playwright.sync_api import FrameLocator, Keyboard, Download, FilePayload
+from playwright.sync_api import FrameLocator, Keyboard, Download
 from dendrite_sdk.sync_api._api.browser_api_client import BrowserAPIClient
 from dendrite_sdk.sync_api._core._js import GENERATE_DENDRITE_IDS_SCRIPT
 from dendrite_sdk.sync_api._core._type_spec import PlaywrightPage
@@ -102,18 +102,6 @@ class Page(
         if not re.match("^\\w+://", url):
             url = f"https://{url}"
         self.playwright_page.goto(url, timeout=timeout, wait_until=wait_until)
-
-    def get_download(self, timeout: float = 30000) -> Download:
-        """
-        Retrieves the download event associated with.
-
-        Args:
-            timeout (float, optional): The maximum amount of time (in milliseconds) to wait for the download to complete. Defaults to 30.
-
-        Returns:
-            The downloaded file data.
-        """
-        return self.dendrite_browser._get_download(self.playwright_page, timeout)
 
     def _get_context(self, element: Any) -> Union[PlaywrightPage, FrameLocator]:
         """
@@ -234,33 +222,6 @@ class Page(
             None
         """
         self.scroll_to_bottom()
-
-    def upload_files(
-        self,
-        files: Union[
-            str,
-            pathlib.Path,
-            FilePayload,
-            Sequence[Union[str, pathlib.Path]],
-            Sequence[FilePayload],
-        ],
-        timeout: float = 30000,
-    ) -> None:
-        """
-        Uploads files to the page using a file chooser.
-
-        Args:
-            files (Union[str, pathlib.Path, FilePayload, Sequence[Union[str, pathlib.Path]], Sequence[FilePayload]]): The file(s) to be uploaded.
-                This can be a file path, a `FilePayload` object, or a sequence of file paths or `FilePayload` objects.
-            timeout (float, optional): The maximum amount of time (in milliseconds) to wait for the file chooser to be ready. Defaults to 30.
-
-        Returns:
-            None
-        """
-        file_chooser = self.dendrite_browser._get_filechooser(
-            self.playwright_page, timeout
-        )
-        file_chooser.set_files(files)
 
     def get_content(self):
         """

--- a/dendrite_sdk/sync_api/_core/mixin/upload_download_mixin.py
+++ b/dendrite_sdk/sync_api/_core/mixin/upload_download_mixin.py
@@ -1,0 +1,49 @@
+import pathlib
+from typing import Sequence, Union
+from playwright.sync_api import Download, FilePayload
+from dendrite_sdk.sync_api._core.protocol.page_protocol import DendritePageProtocol
+
+
+class DownloadUploadMixin(DendritePageProtocol):
+
+    def get_download(self, timeout: float = 30000) -> Download:
+        """
+        Gets the most recent download from the browser.
+
+        Args:
+            timeout (float, optional): The maximum amount of time (in milliseconds) to wait for the download to complete. Defaults to 30.
+
+        Returns:
+            The downloaded file data.
+        """
+        browser = self._get_dendrite_browser()
+        page = self._get_page()
+        download = browser._get_download(page.playwright_page, timeout)
+        return download
+
+    def upload_files(
+        self,
+        files: Union[
+            str,
+            pathlib.Path,
+            FilePayload,
+            Sequence[Union[str, pathlib.Path]],
+            Sequence[FilePayload],
+        ],
+        timeout: float = 30000,
+    ) -> None:
+        """
+        Uploads files to the page using a file chooser.
+
+        Args:
+            files (Union[str, pathlib.Path, FilePayload, Sequence[Union[str, pathlib.Path]], Sequence[FilePayload]]): The file(s) to be uploaded.
+                This can be a file path, a `FilePayload` object, or a sequence of file paths or `FilePayload` objects.
+            timeout (float, optional): The maximum amount of time (in milliseconds) to wait for the file chooser to be ready. Defaults to 30.
+
+        Returns:
+            None
+        """
+        browser = self._get_dendrite_browser()
+        page = self._get_page()
+        file_chooser = browser._get_filechooser(page.playwright_page, timeout)
+        file_chooser.set_files(files)


### PR DESCRIPTION
Arian, would be great if you could look closer at this new mixin to see if it conflicts with the remotebrowser's download functionality.

Also, I didn't manage to get this rather simple example to work, it times out. Any ideas why:

client = BrowserbaseBrowser(
    dendrite_api_key=os.getenv("DENDRITE_API_KEY"),
    openai_api_key=os.getenv("OPENAI_API_KEY"),
    anthropic_api_key=os.getenv("ANTHROPIC_API_KEY"),
    enable_downloads=True,
)
client.goto(
    "https://github.com/dendrite-systems/dendrite-python-sdk/blob/main/scripts/generate_sync.py"
)
client.click("download raw button")
download = client.get_download()
print(download.save_as("generate_sync.py"))
client.close()