### PR TITLE
Den 407 fix timeout on large screenshots

### DIFF
--- a/dendrite_sdk/sync_api/_core/_impl_mapping.py
+++ b/dendrite_sdk/sync_api/_core/_impl_mapping.py
@@ -1,14 +1,18 @@
 from typing import Any, Dict, Optional, Type
 from dendrite_sdk.sync_api._core._impl_browser import ImplBrowser, LocalImpl
 from dendrite_sdk.sync_api._ext_impl.browserbase._impl import BrowserBaseImpl
+from dendrite_sdk.sync_api._ext_impl.browserless._impl import BrowserlessImpl
+from dendrite_sdk.sync_api._ext_impl.browserless._settings import BrowserlessConfig
 from dendrite_sdk.remote import Providers
 from dendrite_sdk.remote.browserbase_config import BrowserbaseConfig
 
 IMPL_MAPPING: Dict[Type[Providers], Type[ImplBrowser]] = {
-    BrowserbaseConfig: BrowserBaseImpl
+    BrowserbaseConfig: BrowserBaseImpl,
+    BrowserlessConfig: BrowserlessImpl,
 }
-SETTINGS_CLASSES: Dict[str, Type[BrowserbaseConfig]] = {
-    "browserbase": BrowserbaseConfig
+SETTINGS_CLASSES: Dict[str, Type[Providers]] = {
+    "browserbase": BrowserbaseConfig,
+    "browserless": BrowserlessConfig,
 }
 
 

--- a/dendrite_sdk/sync_api/_core/mixin/extract.py
+++ b/dendrite_sdk/sync_api/_core/mixin/extract.py
@@ -113,15 +113,6 @@ class ExtractionMixin(DendritePageProtocol):
             prompt = ""
         init_start_time = time.time()
         page = self._get_page()
-        page_information = page.get_page_information()
-        extract_dto = ExtractDTO(
-            page_information=page_information,
-            api_config=self._get_dendrite_browser().api_config,
-            prompt=prompt,
-            return_data_json_schema=json_schema,
-            use_screenshot=True,
-            use_cache=use_cache,
-        )
         delay = 1
         while True:
             elapsed_time = time.time() - init_start_time
@@ -130,6 +121,15 @@ class ExtractionMixin(DendritePageProtocol):
                     f"Extraction process exceeded the timeout of {timeout} seconds"
                 )
             start_time = time.time()
+            page_information = page.get_page_information()
+            extract_dto = ExtractDTO(
+                page_information=page_information,
+                api_config=self._get_dendrite_browser().api_config,
+                prompt=prompt,
+                return_data_json_schema=json_schema,
+                use_screenshot=True,
+                use_cache=use_cache,
+            )
             res = self._get_browser_api_client().extract(extract_dto)
             request_time = time.time() - start_time
             if res.status != "loading":

--- a/dendrite_sdk/sync_api/_ext_impl/browserbase/_impl.py
+++ b/dendrite_sdk/sync_api/_ext_impl/browserbase/_impl.py
@@ -10,7 +10,6 @@ from dendrite_sdk.sync_api._ext_impl.browserbase._client import BrowserbaseClien
 from playwright.sync_api import Playwright
 from loguru import logger
 from dendrite_sdk.sync_api._ext_impl.browserbase._download import BrowserbaseDownload
-from dendrite_sdk.sync_api._ext_impl.browserbase._settings import BrowserBaseSettings
 
 
 class BrowserBaseImpl(ImplBrowser):

--- a/dendrite_sdk/sync_api/_ext_impl/browserbase/_settings.py
+++ b/dendrite_sdk/sync_api/_ext_impl/browserbase/_settings.py
@@ -1,8 +1,0 @@
-from pydantic import BaseModel
-
-
-class BrowserBaseSettings(BaseModel):
-    api_key: str
-    project_id: str
-    enable_proxy: bool = False
-    enable_stealth: bool = True

--- a/dendrite_sdk/sync_api/_ext_impl/browserless/_impl.py
+++ b/dendrite_sdk/sync_api/_ext_impl/browserless/_impl.py
@@ -1,0 +1,53 @@
+import json
+from typing import TYPE_CHECKING, Optional
+from dendrite_sdk._common._exceptions.dendrite_exception import BrowserNotLaunchedError
+from dendrite_sdk.sync_api._core._impl_browser import ImplBrowser
+from dendrite_sdk.sync_api._core._type_spec import PlaywrightPage
+from dendrite_sdk.sync_api._ext_impl.browserless._settings import BrowserlessConfig
+
+if TYPE_CHECKING:
+    from dendrite_sdk.sync_api._core.dendrite_browser import Dendrite
+from dendrite_sdk.sync_api._ext_impl.browserbase._client import BrowserbaseClient
+from playwright.sync_api import Playwright
+from loguru import logger
+import urllib.parse
+from dendrite_sdk.sync_api._ext_impl.browserbase._download import BrowserbaseDownload
+
+
+class BrowserlessImpl(ImplBrowser):
+
+    def __init__(self, settings: BrowserlessConfig) -> None:
+        self.settings = settings
+        self._session_id: Optional[str] = None
+
+    def stop_session(self):
+        pass
+
+    def start_browser(self, playwright: Playwright, pw_options: dict):
+        logger.debug("Starting browser")
+        url = self._format_connection_url(pw_options)
+        logger.debug(f"Connecting to browser at {url}")
+        return playwright.chromium.connect_over_cdp(url)
+
+    def _format_connection_url(self, pw_options: dict) -> str:
+        url = self.settings.url.rstrip("?").rstrip("/")
+        query = {
+            "token": self.settings.api_key,
+            "blockAds": self.settings.block_ads,
+            "launch": json.dumps(pw_options),
+        }
+        if self.settings.proxy:
+            query["proxy"] = (self.settings.proxy,)
+            query["proxyCountry"] = (self.settings.proxy_country,)
+        return f"{url}?{urllib.parse.urlencode(query)}"
+
+    def configure_context(self, browser: "Dendrite"):
+        pass
+
+    def get_download(
+        self,
+        dendrite_browser: "Dendrite",
+        pw_page: PlaywrightPage,
+        timeout: float = 30000,
+    ) -> BrowserbaseDownload:
+        raise NotImplementedError("Downloads are not supported for Browserless")

--- a/dendrite_sdk/sync_api/_ext_impl/browserless/_settings.py
+++ b/dendrite_sdk/sync_api/_ext_impl/browserless/_settings.py
@@ -1,0 +1,24 @@
+import os
+from typing import Any, Optional
+from pydantic import BaseModel, Field, TypeAdapter, ValidationError, model_validator
+from dendrite_sdk.exceptions import MissingApiKeyError
+
+
+class BrowserlessConfig:
+
+    def __init__(
+        self,
+        url: str = "wss://production-sfo.browserless.io",
+        api_key: Optional[str] = None,
+        proxy: Optional[str] = None,
+        proxy_country: Optional[str] = None,
+        block_ads: bool = False,
+    ):
+        api_key = api_key if api_key is not None else os.getenv("BROWSERLESS_API_KEY")
+        if api_key is None:
+            raise MissingApiKeyError("BROWSERLESS_API_KEY")
+        self.url = url
+        self.api_key = api_key
+        self.block_ads = block_ads
+        self.proxy = proxy
+        self.proxy_country = proxy_country


### PR DESCRIPTION
For large pages the screenshot manager times out. To combat this, I added a temporary fix to detect large pages and use a viewport screenshot instead.