### PR TITLE
Den 422 fix timeout of extract and get element

### DIFF
--- a/dendrite_sdk/async_api/_core/dendrite_page.py
+++ b/dendrite_sdk/async_api/_core/dendrite_page.py
@@ -34,6 +34,7 @@ from dendrite_sdk.async_api._core.mixin.extract import ExtractionMixin
 from dendrite_sdk.async_api._core.mixin.fill_fields import FillFieldsMixin
 from dendrite_sdk.async_api._core.mixin.get_element import GetElementMixin
 from dendrite_sdk.async_api._core.mixin.keyboard import KeyboardMixin
+from dendrite_sdk.async_api._core.mixin.markdown import MarkdownMixin
 from dendrite_sdk.async_api._core.mixin.wait_for import WaitForMixin
 from dendrite_sdk.async_api._core.models.page_information import PageInformation
 
@@ -54,6 +55,7 @@ from dendrite_sdk.async_api._core._utils import (
 
 
 class AsyncPage(
+    MarkdownMixin,
     ExtractionMixin,
     WaitForMixin,
     AskMixin,

--- a/dendrite_sdk/async_api/_core/mixin/extract.py
+++ b/dendrite_sdk/async_api/_core/mixin/extract.py
@@ -18,7 +18,7 @@ from dendrite_sdk.async_api._core._managers.navigation_tracker import Navigation
 from loguru import logger
 
 
-CACHE_TIMEOUT = 5000
+CACHE_TIMEOUT = 5
 
 
 class ExtractionMixin(DendritePageProtocol):
@@ -106,7 +106,9 @@ class ExtractionMixin(DendritePageProtocol):
             prompt (Optional[str]): The prompt to describe the information to extract.
             type_spec (Optional[TypeSpec], optional): The type specification for the extracted data.
             use_cache (bool, optional): Whether to use cached results. Defaults to True.
-            timeout (int, optional): The maximum time to wait for extraction in seconds. Defaults to 180 seconds, which is 3 minutes.
+            timeout (int, optional): Maximum time in milliseconds for the entire operation. If use_cache=True,
+                up to 5000ms will be spent attempting to use cached scripts before falling back to the
+                extraction agent for the remaining time that will attempt to generate a new script. Defaults to 15000 (15 seconds).
 
         Returns:
             ExtractResponse: The extracted data wrapped in a ExtractResponse object.

--- a/dendrite_sdk/async_api/_core/mixin/get_element.py
+++ b/dendrite_sdk/async_api/_core/mixin/get_element.py
@@ -13,7 +13,7 @@ from dendrite_sdk.async_api._core.protocol.page_protocol import DendritePageProt
 from dendrite_sdk.async_api._core.models.api_config import APIConfig
 
 
-CACHE_TIMEOUT = 5000
+CACHE_TIMEOUT = 5
 
 
 class GetElementMixin(DendritePageProtocol):
@@ -31,7 +31,9 @@ class GetElementMixin(DendritePageProtocol):
         Args:
             prompt_or_elements (str): The prompt describing the elements to be retrieved.
             use_cache (bool, optional): Whether to use cached results. Defaults to True.
-            timeout (int, optional): The total timeout (in milliseconds) until the last request is sent to the API. Defaults to 15000 (15 seconds).
+            timeout (int, optional): Maximum time in milliseconds for the entire operation. If use_cache=True,
+                up to 5000ms will be spent attempting to use cached selectors before falling back to the
+                find element agent for the remaining time. Defaults to 15000 (15 seconds).
             context (str, optional): Additional context for the retrieval. Defaults to an empty string.
 
         Returns:
@@ -52,7 +54,9 @@ class GetElementMixin(DendritePageProtocol):
         Args:
             prompt_or_elements (Dict[str, str]): A dictionary where keys are field names and values are prompts describing the elements to be retrieved.
             use_cache (bool, optional): Whether to use cached results. Defaults to True.
-            timeout (int, optional): The total timeout (in milliseconds) until the last request is sent to the API. Defaults to 3000.
+            timeout (int, optional): Maximum time in milliseconds for the entire operation. If use_cache=True,
+                up to 5000ms will be spent attempting to use cached selectors before falling back to the
+                find element agent for the remaining time. Defaults to 15000 (15 seconds).
             context (str, optional): Additional context for the retrieval. Defaults to an empty string.
 
         Returns:
@@ -75,7 +79,9 @@ class GetElementMixin(DendritePageProtocol):
         Args:
             prompt_or_elements (Union[str, Dict[str, str]]): The prompt or dictionary of prompts for element retrieval.
             use_cache (bool, optional): Whether to use cached results. Defaults to True.
-            timeout (int, optional): The total timeout (in milliseconds) until the last request is sent to the API. Defaults to 3000.
+            timeout (int, optional): Maximum time in milliseconds for the entire operation. If use_cache=True,
+                up to 5000ms will be spent attempting to use cached selectors before falling back to the
+                find element agent for the remaining time. Defaults to 15000 (15 seconds).
             context (str, optional): Additional context for the retrieval. Defaults to an empty string.
 
         Returns:
@@ -89,7 +95,7 @@ class GetElementMixin(DendritePageProtocol):
             prompt_or_elements,
             only_one=False,
             use_cache=use_cache,
-            timeout=timeout,
+            timeout=timeout / 1000,
         )
 
     async def get_element(
@@ -104,7 +110,9 @@ class GetElementMixin(DendritePageProtocol):
         Args:
             prompt (str): The prompt describing the element to be retrieved.
             use_cache (bool, optional): Whether to use cached results. Defaults to True.
-            timeout (int, optional): The total timeout (in milliseconds) until the last request is sent to the API. Defaults to 15000 (15 seconds).
+            timeout (int, optional): Maximum time in milliseconds for the entire operation. If use_cache=True,
+                up to 5000ms will be spent attempting to use cached selectors before falling back to the
+                find element agent for the remaining time. Defaults to 15000 (15 seconds).
 
         Returns:
             AsyncElement: The retrieved element.
@@ -113,7 +121,7 @@ class GetElementMixin(DendritePageProtocol):
             prompt,
             only_one=True,
             use_cache=use_cache,
-            timeout=timeout,
+            timeout=timeout / 1000,
         )
 
     @overload
@@ -131,7 +139,9 @@ class GetElementMixin(DendritePageProtocol):
             prompt (Union[str, Dict[str, str]]): The prompt describing the element to be retrieved.
             only_one (Literal[True]): Indicates that only one element should be retrieved.
             use_cache (bool): Whether to use cached results.
-            timeout: The total timeout (in milliseconds) until the last request is sent to the API.
+            timeout (int, optional): Maximum time in milliseconds for the entire operation. If use_cache=True,
+                up to 5000ms will be spent attempting to use cached selectors before falling back to the
+                find element agent for the remaining time. Defaults to 15000 (15 seconds).
 
         Returns:
             AsyncElement: The retrieved element.
@@ -152,7 +162,9 @@ class GetElementMixin(DendritePageProtocol):
             prompt (str): The prompt describing the elements to be retrieved.
             only_one (Literal[False]): Indicates that multiple elements should be retrieved.
             use_cache (bool): Whether to use cached results.
-            timeout: The total timeout (in milliseconds) until the last request is sent to the API.
+            timeout (int, optional): Maximum time in milliseconds for the entire operation. If use_cache=True,
+                up to 5000ms will be spent attempting to use cached selectors before falling back to the
+                find element agent for the remaining time. Defaults to 15000 (15 seconds).
 
         Returns:
             List[AsyncElement]: A list of retrieved elements.
@@ -178,7 +190,9 @@ class GetElementMixin(DendritePageProtocol):
             prompt_or_elements (Union[str, Dict[str, str]]): The prompt or dictionary of prompts for element retrieval.
             only_one (bool): Whether to retrieve only one element or a list of elements.
             use_cache (bool): Whether to use cached results.
-            timeout (float): The total timeout (in seconds) for the entire operation.
+            timeout (int, optional): Maximum time in milliseconds for the entire operation. If use_cache=True,
+                up to 5000ms will be spent attempting to use cached selectors before falling back to the
+                find element agent for the remaining time. Defaults to 15000 (15 seconds).
 
         Returns:
             Union[AsyncElement, List[AsyncElement], AsyncElementsResponse]: The retrieved element, list of elements, or response object.

--- a/dendrite_sdk/async_api/_core/mixin/markdown.py
+++ b/dendrite_sdk/async_api/_core/mixin/markdown.py
@@ -1,4 +1,7 @@
 from typing import Optional
+from bs4 import BeautifulSoup
+import re
+
 from dendrite_sdk.async_api._core.mixin.extract import ExtractionMixin
 from dendrite_sdk.async_api._core.protocol.page_protocol import DendritePageProtocol
 
@@ -10,8 +13,14 @@ class MarkdownMixin(ExtractionMixin, DendritePageProtocol):
         page = await self._get_page()
         page_information = await page.get_page_information()
         if prompt:
-            extract_prompt = f"Extract and return the html for this requested section of the website:\n\n{prompt}"
-            res = await self.extract(extract_prompt, str)
-            return md(res, heading_style="ATX")
+            extract_prompt = f"Create a script that returns the HTML from one element from the DOM that best matches this requested section of the website.\n\nDescription of section: '{prompt}'\n\nWe will be converting your returned HTML to markdown, so just return ONE stringified HTML element and nothing else. It's OK if extra information is present. Example script: 'response_data = soup.find('tag', {{'attribute': 'value'}}).prettify()'"
+            res = await self.extract(extract_prompt)
+            markdown_text = md(res)
+            # Remove excessive newlines (3 or more) and replace with 2 newlines
+            cleaned_markdown = re.sub(r"\n{3,}", "\n\n", markdown_text)
+            return cleaned_markdown
         else:
-            return md(page_information.raw_html)
+            markdown_text = md(page_information.raw_html)
+            # Remove excessive newlines (3 or more) and replace with 2 newlines
+            cleaned_markdown = re.sub(r"\n{3,}", "\n\n", markdown_text)
+            return cleaned_markdown

--- a/dendrite_sdk/async_api/_core/mixin/wait_for.py
+++ b/dendrite_sdk/async_api/_core/mixin/wait_for.py
@@ -47,7 +47,7 @@ class WaitForMixin(AskMixin, DendritePageProtocol):
 
             page = await self._get_page()
             page_information = await page.get_page_information()
-            prompt_with_instruction = f"Prompt: '{prompt}'\n\nReturn a boolean that determines if the requested information or thing is available on the page."
+            prompt_with_instruction = f"Prompt: '{prompt}'\n\nReturn a boolean that determines if the requested information or thing is available on the page. {round(page_information.time_since_frame_navigated, 2)} seconds have passed since the page first loaded."
 
             try:
                 res = await self.ask(prompt_with_instruction, bool)

--- a/dendrite_sdk/sync_api/_core/dendrite_browser.py
+++ b/dendrite_sdk/sync_api/_core/dendrite_browser.py
@@ -333,7 +333,7 @@ class Dendrite(
             Exception: If there is an issue launching the browser or retrieving the PageManager.
         """
         if not self._active_page_manager:
-            _, _, active_page_manager = self._launch()
+            (_, _, active_page_manager) = self._launch()
             return active_page_manager
         return self._active_page_manager
 

--- a/dendrite_sdk/sync_api/_core/dendrite_page.py
+++ b/dendrite_sdk/sync_api/_core/dendrite_page.py
@@ -16,6 +16,7 @@ from dendrite_sdk.sync_api._core.mixin.extract import ExtractionMixin
 from dendrite_sdk.sync_api._core.mixin.fill_fields import FillFieldsMixin
 from dendrite_sdk.sync_api._core.mixin.get_element import GetElementMixin
 from dendrite_sdk.sync_api._core.mixin.keyboard import KeyboardMixin
+from dendrite_sdk.sync_api._core.mixin.markdown import MarkdownMixin
 from dendrite_sdk.sync_api._core.mixin.wait_for import WaitForMixin
 from dendrite_sdk.sync_api._core.models.page_information import PageInformation
 
@@ -27,6 +28,7 @@ from dendrite_sdk.sync_api._core._utils import expand_iframes
 
 
 class Page(
+    MarkdownMixin,
     ExtractionMixin,
     WaitForMixin,
     AskMixin,

--- a/dendrite_sdk/sync_api/_core/mixin/markdown.py
+++ b/dendrite_sdk/sync_api/_core/mixin/markdown.py
@@ -1,4 +1,6 @@
 from typing import Optional
+from bs4 import BeautifulSoup
+import re
 from dendrite_sdk.sync_api._core.mixin.extract import ExtractionMixin
 from dendrite_sdk.sync_api._core.protocol.page_protocol import DendritePageProtocol
 from markdownify import markdownify as md
@@ -10,8 +12,12 @@ class MarkdownMixin(ExtractionMixin, DendritePageProtocol):
         page = self._get_page()
         page_information = page.get_page_information()
         if prompt:
-            extract_prompt = f"Extract and return the html for this requested section of the website:\n\n{prompt}"
-            res = self.extract(extract_prompt, str)
-            return md(res, heading_style="ATX")
+            extract_prompt = f"Create a script that returns the HTML from one element from the DOM that best matches this requested section of the website.\n\nDescription of section: '{prompt}'\n\nWe will be converting your returned HTML to markdown, so just return ONE stringified HTML element and nothing else. It's OK if extra information is present. Example script: 'response_data = soup.find('tag', {{'attribute': 'value'}}).prettify()'"
+            res = self.extract(extract_prompt)
+            markdown_text = md(res)
+            cleaned_markdown = re.sub("\\n{3,}", "\n\n", markdown_text)
+            return cleaned_markdown
         else:
-            return md(page_information.raw_html)
+            markdown_text = md(page_information.raw_html)
+            cleaned_markdown = re.sub("\\n{3,}", "\n\n", markdown_text)
+            return cleaned_markdown

--- a/dendrite_sdk/sync_api/_core/mixin/wait_for.py
+++ b/dendrite_sdk/sync_api/_core/mixin/wait_for.py
@@ -35,7 +35,7 @@ class WaitForMixin(AskMixin, DendritePageProtocol):
                 break
             page = self._get_page()
             page_information = page.get_page_information()
-            prompt_with_instruction = f"Prompt: '{prompt}'\n\nReturn a boolean that determines if the requested information or thing is available on the page."
+            prompt_with_instruction = f"Prompt: '{prompt}'\n\nReturn a boolean that determines if the requested information or thing is available on the page. {round(page_information.time_since_frame_navigated, 2)} seconds have passed since the page first loaded."
             try:
                 res = self.ask(prompt_with_instruction, bool)
                 if res:

--- a/dendrite_sdk/sync_api/_dom/util/mild_strip.py
+++ b/dendrite_sdk/sync_api/_dom/util/mild_strip.py
@@ -26,7 +26,7 @@ def _mild_strip(soup: BeautifulSoup, keep_d_id: bool = True) -> None:
             continue
         tag.attrs = {
             attr: value[:100] if isinstance(value, str) else value
-            for attr, value in tag.attrs.items()
+            for (attr, value) in tag.attrs.items()
         }
         if keep_d_id == False:
             del tag["d-id"]


### PR DESCRIPTION
With these changes the cache is tried for 5 seconds, then the agents are tried up until the timeout. Docstrings improved too and built sync.